### PR TITLE
Make /usr/lib/systemd/system if it doesn't exist

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -432,6 +432,8 @@ install_services() {
   update_etc_hosts
   set_login
 
+mkdir -p /usr/lib/systemd/system
+
   install_depends
   install_scripts
   install_Caddyfile


### PR DESCRIPTION
I've just tried installing your fork in a rootfs downloaded from https://github.com/debuerreotype/docker-debian-artifacts and it got confused by /usr/lib/systemd/system not existing by default - I don't know if this a usrmerge related thing? Easy fix anyway!