### PR TITLE
Explicitly install cron

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -20,7 +20,7 @@ install_depends() {
   apt install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
     pulseaudio avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
     php-zip icecast2 swig ffmpeg wget unzip curl cmake make bc libjpeg-dev \
-    zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools
+    zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools cron
 }
 
 


### PR DESCRIPTION
cron isn't actually installed by default in some images and container bases any more! Specifically the official Debian docker/container rootfses. Without it disk space clean-up etc doesn't run.