### PR TITLE
Update requirements-x86.txt

### DIFF
--- a/requirements-x86.txt
+++ b/requirements-x86.txt
@@ -14,3 +14,4 @@ apprise
 paho-mqtt
 pytest==7.1.2
 pytest-mock==3.7.0
+suntime


### PR DESCRIPTION
`suntime` is noted in the arm requirements but not x86. Needed for the Species Stats page