### PR TITLE
Set NumPy version 1 in requirements files

### DIFF
--- a/requirements-x86.txt
+++ b/requirements-x86.txt
@@ -14,3 +14,4 @@ apprise
 paho-mqtt
 pytest==7.1.2
 pytest-mock==3.7.0
+numpy<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pytest==7.1.2
 pytest-mock==3.7.0
 suntime
 altair<5
+numpy<2


### PR DESCRIPTION
Fixes issue #19 which I have also encountered with a clean install.