### PR TITLE
Handle empty audio chunks

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -611,6 +611,8 @@ def handle_client(conn, addr):
                                 print("Detection POST Response Status - ", response.status_code)
                             except BaseException:
                                 print("Cannot POST right now")
+        if not myReturn:
+            myReturn = "No audio to analyse."
         conn.send(myReturn.encode(FORMAT))
 
         # time.sleep(3)


### PR DESCRIPTION
Fixes an issue where a 15 minute hang occurs while waiting for a receive thread if server.py has nothing to send. This can occur when an RTSP stream is producing files but with no detectable audio.